### PR TITLE
💄 #33 Icône à la place de la mention "lien externe"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ Code sous [licence MIT](./LICENSE.md).
 
 Favicon provenant de [Twemoji](https://github.com/twitter/twemoji) par Twitter sous
 licence [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+Icônes provenant de [Font Awesome](https://github.com/FortAwesome/Font-Awesome) sous
+licence [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).

--- a/src/App.vue
+++ b/src/App.vue
@@ -99,8 +99,13 @@ onUnmounted(() => document.removeEventListener("keydown", update));
 
       <div class="definition">
         <a target="_blank" :href="wiktionaryDefinitionLink"
-          >Définition Wiktionnaire (lien externe)</a
-        >
+          >Définition Wiktionnaire<svg role="img" viewBox="0 0 448 480">
+            <title>lien externe</title>
+            <use
+              href="./assets/up-right-from-square-solid.svg#external-link-icon"
+            ></use>
+          </svg>
+        </a>
       </div>
     </div>
   </main>
@@ -142,6 +147,12 @@ main > div {
   margin-top: 20px;
   font-size: 1.4rem;
   text-align: center;
+}
+
+.definition svg {
+  margin-left: 0.4em;
+  width: 0.75em;
+  fill: currentColor;
 }
 
 .v-leave-active {

--- a/src/assets/up-right-from-square-solid.svg
+++ b/src/assets/up-right-from-square-solid.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 448 512"><!--! Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+    <path id="external-link-icon" d="M288 32c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L306.7 128 169.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L352 173.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6V64c0-17.7-14.3-32-32-32H288zM80 64C35.8 64 0 99.8 0 144V400c0 44.2 35.8 80 80 80H336c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v80c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V144c0-8.8 7.2-16 16-16h80c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"/>
+</svg>


### PR DESCRIPTION
J'ai utilisé l'élément `use` dans un `svg` pour pouvoir changer la couleur de l'icône selon le css. Si on inclut le svg avec la balise `img`, on ne peut plus appliquer de css sur ce celui-ci.

Closes #33